### PR TITLE
use c++-native std::stoi for int conversion

### DIFF
--- a/XTEA.cpp
+++ b/XTEA.cpp
@@ -10,6 +10,7 @@
 #include <stdio.h>
 #include <tchar.h>
 #include <Shlwapi.h>
+#include <string>
 
 //this is necessary for using XTEA in 64bit systems
 typedef unsigned int uint32_t;

--- a/XTEA.cpp
+++ b/XTEA.cpp
@@ -55,10 +55,10 @@ int _tmain(int argc, _TCHAR* argv[])
 	// uint32_t encoded_data[2]={0x93FFFF80,0xFF801CA2};
 	
 	if(argc==5){
-		StrToInt64Ex(argv[1],STIF_SUPPORT_HEX,(LONGLONG*)&key[0]);
-		StrToInt64Ex(argv[2],STIF_SUPPORT_HEX,(LONGLONG*)&key[2]);
-		StrToInt64Ex(argv[3],STIF_SUPPORT_HEX,(LONGLONG*)&lzma_data[0]);
-		numrounds=StrToIntA(argv[4]);
+		key[0]=std::stoi(argv[1],nullptr,0);
+		key[2]=std::stoi(argv[2],nullptr,0);
+		lzma_data[0]=std::stoi(argv[3],nullptr,0);
+		numrounds=std::stoi(argv[4],nullptr,0);
 		
 		//adjust the key endianess
 		tmp=key[1];


### PR DESCRIPTION
the old StrToInt64Ex() method will only compile on Windows, while std::stoi will compile anywhere that c++ compiles (windows, linux, macos, bsd, practically anywhere)

and yes, std::stoi also supports hex notation with the proper arguments (eg with argument #3 = 0, which means autodetect)